### PR TITLE
ZNTA-901 - use alternative lib for indented xml writer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,17 +74,6 @@
         <artifactId>zanata-common-util</artifactId>
         <version>${project.version}</version>
       </dependency>
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>2.2.4</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/zanata-adapter-xliff/pom.xml
+++ b/zanata-adapter-xliff/pom.xml
@@ -37,8 +37,9 @@
       <artifactId>stax-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>net.sf.saxon</groupId>
+      <artifactId>Saxon-HE</artifactId>
+      <version>9.4.0-9</version>
     </dependency>
   </dependencies>
 </project>

--- a/zanata-adapter-xliff/src/main/java/org/zanata/adapter/xliff/XliffWriter.java
+++ b/zanata-adapter-xliff/src/main/java/org/zanata/adapter/xliff/XliffWriter.java
@@ -204,6 +204,7 @@ public class XliffWriter extends XliffCommon {
         Serializer serializer = processor.newSerializer();
         serializer.setOutputProperty(Serializer.Property.METHOD, "xml");
         serializer.setOutputProperty(Serializer.Property.INDENT, "yes");
+        serializer.setOutputProperty(Serializer.Property.ENCODING, "utf-8");
         StreamWriterToReceiver writer = null;
 
         try (FileOutputStream fileStream = new FileOutputStream(file)) {

--- a/zanata-adapter-xliff/src/main/java/org/zanata/adapter/xliff/XliffWriter.java
+++ b/zanata-adapter-xliff/src/main/java/org/zanata/adapter/xliff/XliffWriter.java
@@ -209,20 +209,26 @@ public class XliffWriter extends XliffCommon {
 
         try (FileOutputStream fileStream = new FileOutputStream(file)) {
             serializer.setOutputStream(fileStream);
-            writer = serializer.getXMLStreamWriter();
+            try {
+                writer = serializer.getXMLStreamWriter();
 
-            writeHeader(writer, doc, locale);
+                writeHeader(writer, doc, locale);
 
-            writeTransUnits(writer, doc, targetDoc, createSkeletons);
+                writeTransUnits(writer, doc, targetDoc, createSkeletons);
 
-            // end body tag
-            writer.writeEndElement();
-            // end file tag
-            writer.writeEndElement();
-            // end xliff tag
-            writer.writeEndDocument();
-            writer.flush();
-            writer.close();
+                // end body tag
+                writer.writeEndElement();
+                // end file tag
+                writer.writeEndElement();
+                // end xliff tag
+                writer.writeEndDocument();
+                writer.flush();
+            } finally {
+                if (writer != null) {
+                    writer.close();
+                }
+            }
+
         } catch (XMLStreamException e) {
             throw new RuntimeException("Error generating XLIFF file format   ",
                 e);

--- a/zanata-adapter-xliff/src/test/java/org/zanata/adapter/xliff/XliffWriterTest.java
+++ b/zanata-adapter-xliff/src/test/java/org/zanata/adapter/xliff/XliffWriterTest.java
@@ -11,9 +11,12 @@ import java.io.FileNotFoundException;
 import org.junit.Before;
 import org.junit.Test;
 import org.zanata.adapter.xliff.XliffCommon.ValidationType;
+import org.zanata.common.ContentState;
 import org.zanata.common.LocaleId;
 import org.zanata.rest.dto.resource.Resource;
 import org.zanata.rest.dto.resource.TextFlow;
+import org.zanata.rest.dto.resource.TextFlowTarget;
+import org.zanata.rest.dto.resource.TranslationsResource;
 
 public class XliffWriterTest {
     private String testDir = "src/test/resources/";
@@ -73,5 +76,22 @@ public class XliffWriterTest {
         doc.setName(generatedDocName);
 
         XliffWriter.write(new File(generateDir), doc, "en-US");
+    }
+
+    @Test
+    public void testWriteXliff() throws Exception {
+
+        Resource doc = new Resource("hello");
+        doc.getTextFlows()
+                .add(new TextFlow("first", LocaleId.EN_US, "first text"));
+        TranslationsResource translationsResource = new TranslationsResource();
+
+        TextFlowTarget target = new TextFlowTarget("first");
+        target.setContents("第一个");
+        target.setState(ContentState.Translated);
+        translationsResource.getTextFlowTargets().add(target);
+        XliffWriter
+                .writeFile(new File(generateDir, "xliff_writer.xml"), doc, "zh",
+                        translationsResource, true);
     }
 }


### PR DESCRIPTION
depend on a library rather than an internal Sun class.
note: fedora has this library but an older version. http://pkgs.fedoraproject.org/cgit/rpms/saxon.git/tree/saxon.spec


see https://zanata.atlassian.net/browse/ZNTA-901