### PR TITLE
chore(dependency): Saxon-HE-9.5.1-8

### DIFF
--- a/zanata-adapter-xliff/pom.xml
+++ b/zanata-adapter-xliff/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>9.4.0-9</version>
+      <version>9.5.1-8</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Server need this to be able to compile in Java 8

Downstream:
https://github.com/zanata/zanata-client/pull/108
https://github.com/zanata/zanata-server/pull/1117

The future release cannot be pushed to Fedora until Saxon-HE-9.5.1-8 is in Fedora